### PR TITLE
Added the explicit shell for the cat version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DOCKER_REPO ?= gcr.io/online-bridge-hackathon-2020
-VERSION ?= $(cat VERSION)
+VERSION ?= $(shell cat VERSION)
 DOCKER_TAG=${DOCKER_REPO}/dds-api:${VERSION}
 
 EXTERNAL_ADDRES ?= dds.hackathon.globalbridge.app


### PR DESCRIPTION
This made things work for me in windows when calling make and
seems to be what others online do for sample commands from cross
platform docker Makefiles like
https://gist.github.com/mpneuried/0594963ad38e68917ef189b4e6a269db
which I found when googling sample docker makefiles