### PR TITLE
Update __init__.py

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,6 @@
+# Check compatibility
+try:
+  name = "Monty"
+  eval("f\"Hello, {name}\"")
+except SyntaxError:
+  raise RuntimeError("DDS requires f-string support, introduced in Python 3.6")


### PR DESCRIPTION
Require support for f-string syntax, as introduced in Python 3.6.