### PR TITLE
Update dds to include multiple fixes from PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,20 @@ GCP_PROJECT ?= online-bridge-hackathon-2020
 GKE_CLUSTER_NAME ?= hackathon-cluster
 GKE_ZONE ?= europe-west3-b
 
+LIBDDS_REMOTE ?= libdds_for_cachebust
+LIBDDS_REPO ?= https://github.com/suokko/dds
+
 release: build push
 
-build:
-	docker build -t ${DOCKER_TAG} .
+.git/refs/remotes/${LIBDDS_REMOTE}/master:
+	git remote add ${LIBDDS_REMOTE} ${LIBDDS_REPO}
+	git fetch ${LIBDDS_REMOTE}
+
+build: .git/refs/remotes/${LIBDDS_REMOTE}/master
+	git fetch ${LIBDDS_REMOTE}
+	docker build -t ${DOCKER_TAG} \
+		--build-arg CACHEBUST=$(shell git describe ${LIBDDS_REMOTE}/master) \
+		.
 
 push:
 	docker push ${DOCKER_TAG}

--- a/src/dds.py
+++ b/src/dds.py
@@ -78,9 +78,9 @@ def encode_deal(hands):
 class DDS:
     def __init__(self, max_threads=0):
         if platform.system() == "Windows":
-            libname = "dds.dll"
+            libname = "libdds.dll"
         else:
-            libname = "libdds.so"
+            libname = "libdds.so.2"
         self.libdds = libloader.LoadLibrary(libname)
         self.libdds.SetMaxThreads(max_threads)
 


### PR DESCRIPTION
Changes to docker configuration include requirements for cmake based
build to work. I removed libboost-thread because it is optional
dependency which provides same functional as std::thread based
implementation.

As libdds build implementation requires at least cmake 3.12 I decided to
upgrade the image to use Debian stable (Buster).

Same time I decided to tell apt-get to install minimum required packages
with --no-install-recommends argument. It reduces number of packages
installed a bit.

The cmake build system also adds library versioning and prepended lib to
windows name. These changes require filename change to libname in
python.

libdds changes in https://github.com/suokko/dds include:
* Fix for Mac failing to detect available memory when loading library
  second time
* Fix for exit crash because of undefined order for static destructors.
* Fix for Linux memory size detection
* Fix was integer promotions for systems with unsigned char
* New dll entry SolveAllBoardsBin

Signed-off-by: Pauli <suokkos@gmail.com>