### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.log
 *DS*Store*
 
+src/dump.txt


### PR DESCRIPTION
Ignore dump files produced by ddslib when it crashes.