### PR TITLE
Fix data race when setting maximum thread number

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -8,6 +8,10 @@ app = Flask(__name__)
 CORS(app)
 api = Api(app)
 
+# When SetMaxThreads is called there must not be any other threads calling
+# libdds. The easiest way to avoid parallel calls is to keep only one DDS object
+# as long as server runs.
+dds = DDS(max_threads=2)
 
 class DDSTable(Resource):
     def get(self):
@@ -18,7 +22,6 @@ class DDSTable(Resource):
         data = request.get_json()
         # Verify the data here
         # self.verifyinput(data)
-        dds = DDS(max_threads=2)
         dds_table = dds.calc_dd_table(data['hands'])
         return dds_table
 


### PR DESCRIPTION
Calls to SetMaxThreads or SetResources aren't thread safe. This requires
caller to provide synchronization with any other libdds call. To avoid
synchronization requirement I decided to move SetMaxThreads call to
initialization.

Signed-off-by: Pauli <suokkos@gmail.com>

---

I agree this deserves separation from configuration changes. The one line change make much bigger impact than my predicted while writing it. This also means my original comment was outdated today to make sure people will know in future why DDS object is created as a global.