### PR TITLE
Add test simulating two simultaneous post request

### DIFF
--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,0 +1,81 @@
+# Copyright 2020 Pauli Nieminen and the Bridge Hackathon contributors
+#
+#   Use of this source code is governed by an MIT-style
+#   license that can be found in the LICENSE file or at
+#   https://opensource.org/licenses/MIT
+
+# To run the tests from the command line:
+# cd DDS
+# python3 -m unittest discover
+
+import unittest
+import sys
+import json
+
+# import dds in api.py requires appending path manually
+sys.path.append('src')
+
+from api import app
+
+from test.utilities import string_to_hand
+
+class TestAPI(unittest.TestCase):
+    """
+    Tests the server handler implementations.
+    """
+
+    @classmethod
+    def setUp(self):
+        self.service = app.test_client()
+
+    def test_parallel_post(self):
+        """
+        Tests parallel access to calcDDTable. Cards are from libdds/hands/list100.txt
+        PBN 0 2 0 3 "N:KT.6.AKQ64.A7654 Q53.KT9874.T2.Q2 AJ876.A2.953.KJT 942.QJ53.J87.983"
+        FUT 10 1 1 1 0 0 2 2 0 3 3 3 5 12 2 4 8 11 9 3 9 0 0 2048 0 0 128 0 0 0 256 0 0 0 0 0 0 0 0 0 0
+        TABLE 13 0 13 0 8 5 8 5 13 0 13 0 13 0 13 0 13 0 13 0
+        """
+
+        deal = dict(
+            hands = dict(
+                N = string_to_hand("KT.6.AKQ64.A7654"),
+                E = string_to_hand("Q53.KT9874.T2.Q2"),
+                S = string_to_hand("AJ876.A2.953.KJT"),
+                W = string_to_hand("942.QJ53.J87.983")
+                )
+            )
+
+        result = dict(
+            S = dict(N = 13, E = 0, S = 13, W = 0),
+            H = dict(N = 8, E = 5, S = 8, W = 5),
+            D = dict(N = 13, E = 0, S = 13, W = 0),
+            C = dict(N = 13, E = 0, S = 13, W = 0),
+            N = dict(N = 13, E = 0, S = 13, W = 0)
+        )
+
+        def test_fn(self, deal, solutions):
+            for i in range(2):
+                solutions.append(self.service.post('/api/dds-table/', json=deal))
+
+        solutions = []
+        solutions2 = []
+
+        t2 = threading.Thread(target=test_fn, args=(self, deal, solutions2))
+        t2.start()
+        test_fn(self, deal, solutions)
+        t2.join()
+        solutions.extend(solutions2)
+
+        for solution in solutions:
+            for denomination in ['C', 'D', 'H', 'S', 'N']:
+                for declarer in ['N', 'S', 'E', 'W']:
+                    data = json.loads(solution.data);
+                    self.assertEqual(result[denomination][declarer],
+                            data[denomination][declarer],
+                            declarer + ' should make ' + \
+                                    str(result[denomination][declarer]) + ' in ' + \
+                                    denomination);
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -18,6 +18,7 @@ sys.path.append('src')
 from api import app
 
 from test.utilities import string_to_hand
+from test.utilities import run_in_threads
 
 class TestAPI(unittest.TestCase):
     """
@@ -53,18 +54,13 @@ class TestAPI(unittest.TestCase):
             N = dict(N = 13, E = 0, S = 13, W = 0)
         )
 
-        def test_fn(self, deal, solutions):
+        def test_fn(self, deal):
             for i in range(2):
-                solutions.append(self.service.post('/api/dds-table/', json=deal))
+                response = self.service.post('/api/dds-table/', json=deal)
+                self.assertEqual(response.status_code, 200)
+                yield response
 
-        solutions = []
-        solutions2 = []
-
-        t2 = threading.Thread(target=test_fn, args=(self, deal, solutions2))
-        t2.start()
-        test_fn(self, deal, solutions)
-        t2.join()
-        solutions.extend(solutions2)
+        solutions = run_in_threads(2, test_fn, args=(self, deal))
 
         for solution in solutions:
             for denomination in ['C', 'D', 'H', 'S', 'N']:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -19,6 +19,7 @@ from api import app
 
 from test.utilities import string_to_hand
 from test.utilities import run_in_threads
+from test.utilities import check_DD_table_results
 
 class TestAPI(unittest.TestCase):
     """
@@ -58,20 +59,11 @@ class TestAPI(unittest.TestCase):
             for i in range(2):
                 response = self.service.post('/api/dds-table/', json=deal)
                 self.assertEqual(response.status_code, 200)
-                yield response
+                yield json.loads(response.data)
 
         solutions = run_in_threads(2, test_fn, args=(self, deal))
 
-        for solution in solutions:
-            for denomination in ['C', 'D', 'H', 'S', 'N']:
-                for declarer in ['N', 'S', 'E', 'W']:
-                    data = json.loads(solution.data);
-                    self.assertEqual(result[denomination][declarer],
-                            data[denomination][declarer],
-                            declarer + ' should make ' + \
-                                    str(result[denomination][declarer]) + ' in ' + \
-                                    denomination);
-
+        check_DD_table_results(self, solutions, result)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -92,3 +92,13 @@ def run_in_threads(num_threads, target, args):
     for thread_return in results:
         for item in thread_return:
             yield item
+
+def check_DD_table_results(test, results, expected):
+    for result in results:
+        for denomination in ['C', 'D', 'H', 'S', 'N']:
+            for declarer in ['N', 'S', 'E', 'W']:
+                test.assertEqual(expected[denomination][declarer],
+                        result[denomination][declarer],
+                        declarer + ' should make ' + \
+                                str(expected[denomination][declarer]) + ' in ' + \
+                                denomination);

--- a/test/utilities.py
+++ b/test/utilities.py
@@ -8,6 +8,8 @@
 #       its test deals. Those are easier to enter but a little more difficult
 #       to read.
 
+from threading import Thread
+
 SUIT_SYMBOLS = ["S", "H", "D", "C"]
 
 def string_to_hand(hand_string):
@@ -62,3 +64,31 @@ def rotate_nesw_to_eswn(nesw):
     for index in range(4):
         eswn.append(nesw[(index + 1) %4])
     return eswn
+
+def run_in_threads(num_threads, target, args):
+    """
+    Helper to run a test using multiple threads with a simulated return value
+    """
+    results = []
+    threads = []
+    # Wrapper to allow thread functions to return or yield their return values
+    def thread_fn(target, args, result):
+        for r in target(*args):
+            result.append(r)
+    for i in range(num_threads):
+        # Reserve a thread local return value
+        results.append([])
+        thread_arguments = (target, args, results[i])
+        # Create and start threads
+        threads.append(Thread(target=thread_fn, args=thread_arguments))
+        threads[i].start()
+
+
+    for t in threads:
+        # Wait for thread exit
+        t.join()
+
+    # collapse results to a single list
+    for thread_return in results:
+        for item in thread_return:
+            yield item


### PR DESCRIPTION
Data race from calling SetMaxThreads/SetResources multiple times got a
simple fix. This is a test case testing we won't repeat same data race
in future.

Signed-off-by: Pauli <suokkos@gmail.com>

--
The branch doesn't have fix so it can crash. This test requires two runs to have a chance to crash when I run test locally. I suspect there is some timing issues with a thread starting.