### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 __pycache__/
 *.pyc
 *.log
-*DS*Store*
-
+.DS_Store
 src/dump.txt


### PR DESCRIPTION
s/*DS*Store*/.DS_Store/

So far GitHub desktop seems to not take either into account. Might as well go with the specific name.