### PR TITLE
Use submodule for libdds build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libdds"]
+	path = libdds
+	url = ../../online-bridge-hackathon/libdds
+	branch = master

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Coding Style
+
+# Issues
+
+# Pull Request
+
+## Managing Submodule
+
+If your changes require libdds changes to be include then there are a few
+extra steps to follow. You have to make sure required libdds changes have been
+merged to [http:://github.com/online-bridge-hackathon/libdds](http:://github.com/online-bridge-hackathon/libdds).
+
+Merging commits to libdds doesn't automatically include merges to the library
+used by service build process. The library version used by service is based on
+the commit attached to the submodule. To update the commit you need to first
+checkout the new commit into your submodule working tree. Then the change needs
+to be staged and committed like source code changes. The following example shows
+steps to update the submodule to the latest commit in the master branch.
+
+```
+cd libdds
+git checkout origin/master
+cd ..
+git add libdds
+git commit
+```
+
+Submodule update can be included in a commit with service code changes for an
+atomic update.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,19 @@ RUN apt-get install -y --no-install-recommends \
   g++ \
   ninja-build
 
-RUN git clone https://github.com/suokko/dds /app
-RUN mkdir -p /app/.build
+# Make sure sources are the latest for the build operation
+ARG CACHEBUST=1
+ADD libdds /app
+
+RUN rm -rf /app/.build && \
+  mkdir -p /app/.build
 
 WORKDIR /app/.build
 
-# Make sure sources are the latest for the build operation
-ARG CACHEBUST=1
-RUN git pull origin && \
 # Configure using RelWithDebInfo. This will help if system is setup to generate
 # a core file in case of crash. Installation prefix is /usr. It uses Ninja
 # generator which has better cmake generator than recursive Makefiles.
-    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+RUN cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_INSTALL_PREFIX=/usr \
       -G Ninja \
       .. && \

--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,14 @@ GCP_PROJECT ?= online-bridge-hackathon-2020
 GKE_CLUSTER_NAME ?= hackathon-cluster
 GKE_ZONE ?= europe-west3-b
 
-LIBDDS_REMOTE ?= libdds_for_cachebust
-LIBDDS_REPO ?= https://github.com/suokko/dds
-
 release: build push
 
-.git/refs/remotes/${LIBDDS_REMOTE}/master:
-	git remote add ${LIBDDS_REMOTE} ${LIBDDS_REPO}
-	git fetch ${LIBDDS_REMOTE}
+libdds/.git:
+	git submodule update --init
 
-build: .git/refs/remotes/${LIBDDS_REMOTE}/master
-	git fetch ${LIBDDS_REMOTE}
+build: libdds/.git
 	docker build -t ${DOCKER_TAG} \
-		--build-arg CACHEBUST=$(shell git describe ${LIBDDS_REMOTE}/master) \
+		--build-arg CACHEBUST=$(shell git --git-dir=libdds/.git describe) \
 		.
 
 push:


### PR DESCRIPTION
Moving libdds to submodule allows front end to update in lockstep if
there will be libdds changes that is best done as an atomic update with
service changes.

Signed-off-by: Pauli <suokkos@gmail.com>