### PR TITLE
Run verbose unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ DOCKER_TAG=${DOCKER_REPO}/dds-api:${VERSION}
 
 EXTERNAL_ADDRES ?= dds.hackathon.globalbridge.app
 
+ifeq (${SILENT},1)
+	VERBOSE_TEST :=
+else
+	VERBOSE_TEST := -v
+endif
+
+
 DDS_K8S_NS ?= dds-api
 GCP_PROJECT ?= online-bridge-hackathon-2020
 GKE_CLUSTER_NAME ?= hackathon-cluster
@@ -44,4 +51,4 @@ ensure_ns:
 	kubectl create ns ${DDS_K8S_NS} || :
 
 run_local_tests:
-	python3 -m unittest discover
+	python3 -m unittest discover ${VERBOSE_TEST}

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -32,7 +32,8 @@ class TestAPI(unittest.TestCase):
 
     def test_parallel_post(self):
         """
-        Tests parallel access to calcDDTable. Cards are from libdds/hands/list100.txt
+        Tests parallel DDSTable post handlers.
+        Cards are from libdds/hands/list100.txt
         PBN 0 2 0 3 "N:KT.6.AKQ64.A7654 Q53.KT9874.T2.Q2 AJ876.A2.953.KJT 942.QJ53.J87.983"
         FUT 10 1 1 1 0 0 2 2 0 3 3 3 5 12 2 4 8 11 9 3 9 0 0 2048 0 0 128 0 0 0 256 0 0 0 0 0 0 0 0 0 0
         TABLE 13 0 13 0 8 5 8 5 13 0 13 0 13 0 13 0 13 0 13 0

--- a/test/test_dds.py
+++ b/test/test_dds.py
@@ -36,6 +36,7 @@ class TestDDS(unittest.TestCase):
 
     def test_one_sample_deal(self):
         """
+        Solve a sample.
             S AQ85
             H AK976
             D 5
@@ -68,6 +69,7 @@ class TestDDS(unittest.TestCase):
 
     def test_ns_make_7_of_everything(self):
         """
+        NS make 13 tricks in everything.
             S AKQJ
             H AKQJ
             D T98
@@ -118,10 +120,10 @@ class TestDDS(unittest.TestCase):
             for declarer in ['E', 'W']:
                 self.assertEqual(13, dds_table[denomination][declarer],
                                  "EW can take 13 tricks in any denomination.")
-        
+
     def test_everyone_makes_3n(self):
         """
-        Unusual deal!
+        Everyone makes 9 tricks in notrump!
         See: https://bridge.thomasoandrews.com/deals/everybody/
 
             S QT9
@@ -192,7 +194,8 @@ class TestDDS(unittest.TestCase):
 
     def test_parallel_CalcDDTable(self):
         """
-        Tests parallel access to calcDDTable. Cards are from libdds/hands/list100.txt
+        Tests parallel access to dds.calc_dd_table.
+        Cards are from libdds/hands/list100.txt
 
         PBN 0 0 4 2 "N:T742.QT6.AJ7.Q64 AQ83.A54.KQ9.T82 K65.J873.653.A97 J9.K92.T842.KJ53"
         FUT 10 3 2 2 1 1 1 3 3 0 0 14 3 6 3 8 11 7 9 6 13 0 0 32 0 128 0 0 0 32 0 5 5 5 5 5 5 5 5 4 4


### PR DESCRIPTION
It is possible libdds crashes which makes it hard to guess which test
caused the crash. Crash could be a rare random crash making it important
to know which test case caused it. Python unittest can print test name
before running it. This would make logs show which test crashed.

Verbose mode prints first line of string in the test case. Some test
cases had a first line less than optimal for verbose out. I decided to
improve first lines to make it easier to match messages to tests.

Signed-off-by: Pauli <suokkos@gmail.com>