### PR TITLE
Automated libdds build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ Uses Bo Hagland's solver https://github.com/dds-bridge/dds -- requires the libdd
 Credit to Alexis Rimbaud of NukkAI for the python dds wrapper.
 
 
-# Build and install libdds.so under MacOS #
+# Build and install libdds library for local testing
 
 ```
-git clone https://github.com/dds-bridge/dds.git
-cd dds/src
-make -f Makefiles/Makefile_Mac_clang_shared THREADING=
-ln libdds.so /usr/local/lib
+make libdds-build
+cd libdds/.build
 ```
+
+The python loader looks for the library from libdds/.build/src. If the file is
+found from build directory then the found library is preferred before a library
+in a system directory.
 
 # Install a local server using Flask, then test it manually:
 

--- a/src/dds.py
+++ b/src/dds.py
@@ -79,6 +79,8 @@ class DDS:
     def __init__(self, max_threads=0):
         if platform.system() == "Windows":
             libname = "libdds.dll"
+        elif platform.system() == "Darwin":
+            libname = "libdds.2.dylib"
         else:
             libname = "libdds.so.2"
         self.libdds = libloader.LoadLibrary(libname)

--- a/src/dds.py
+++ b/src/dds.py
@@ -2,6 +2,7 @@
 
 from ctypes import Structure, c_int, pointer
 import platform
+import os
 
 if platform.system() == "Windows":
     from ctypes import windll as libloader
@@ -13,6 +14,7 @@ SUITS = "SHDC"
 STRAINS = SUITS + "N"
 RANKS = "??23456789TJQKA"
 MAXNOOFBOARDS = 200
+LIBDDSPATH = "libdds/.build/src/"
 
 class Deal(Structure):
     _fields_ = [
@@ -83,6 +85,10 @@ class DDS:
             libname = "libdds.2.dylib"
         else:
             libname = "libdds.so.2"
+
+        if os.path.exists(LIBDDSPATH + libname):
+            libname = LIBDDSPATH + libname
+
         self.libdds = libloader.LoadLibrary(libname)
         self.libdds.SetMaxThreads(max_threads)
 


### PR DESCRIPTION
## Use versioned dylib library name on Mac 

Updates libdds to a version which drops .so suffix from mac builds. This
requires library loading to use correct versioned dylib name on Mac.

## Automate build process for libdds submodule

We can have service Makefile to configure and compile libdds when
run_local_tests target is triggered. The process is split to smaller
steps which include submodule system initialization (first time only),
configure the libdds build, update libdds sources and building libdds.

Library is used directly from build directory using platform specific
environment variable to add libdds build directory into the library
search path.