### PR TITLE
Update docs to automated libdds build

### DIFF
--- a/README.gcp.md
+++ b/README.gcp.md
@@ -7,39 +7,6 @@ For overall project info please see [README.md](https://github.com/online-bridge
 Using your favorite web browser, open a cloud shell terminal at <https://ssh.cloud.google.com/cloudshell>.
 You'll need a free Google account. These days, most people have one already.
 
-# Build and install the C++ library
-
-This repository contains the hackathon's fork of Bo Haglund's double-dummy solver code.
-
-```
-gcloud config set project online-bridge-hackathon-2020
-mkdir ~/bridge-hackathon/
-cd ~/bridge-hackathon/
-git clone https://github.com/online-bridge-hackathon/libdds.git
-cd libdds/
-mkdir .build
-cd .build/
-# Build with debugging symbols. Inexpensive and sometimes useful.
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
-make
-```
-
-Optional, to be sure the library built correctly.
-It will take about six minutes to complete.
-```
-make check
-```
-
-Install the library where Python can find it:
-```
-sudo cmake -DCMAKE_INSTALL_COMPONENT=Runtime -DCMAKE_INSTALL_PREFIX=/usr -P cmake_install.cmake
-```
-
-The cloud shell clears out /usr/lib/ every so often, so add the install command to your *.bashrc* file:
-```
-cd $HOME/bridge-hackathon/dds/.build/ && sudo cmake -DCMAKE_INSTALL_COMPONENT=Runtime -DCMAKE_INSTALL_PREFIX=/usr -P cmake_install.cmake
-```
-
 # Build and test the DDS webservice wrapper for the double-dummy solver library
 
 Note that the C++ project is named **dds** and the webservice project is named **DDS**. Yes, this could be confusing - we plan to rename one or both.
@@ -55,8 +22,9 @@ make run_local_tests
 
 
 ```
-pip3 install -r requirements.txt
 cd ~/bridge-hackathon/DDS/
+pip3 install -r requirements.txt
+make libdds-build
 python3 -m src.api
 ```
 

--- a/README.libdds.md
+++ b/README.libdds.md
@@ -1,0 +1,19 @@
+
+# Change the build configuring of the C++ library
+
+You can modify the build configuration after building the library. There is
+cmake GUI tools which can help modify configuration variables. Example uses
+curses GUI.
+
+```
+ccmake -S libdds -B libdds/.build
+```
+
+# Run the test of the C++ library
+
+You can verify the C++ library works by running the test of the C++ library.
+
+```
+make libdds-build
+make -C libdds/.build check
+```

--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ If you want to change the C++ library's build configuration,
 # Install a local server using Flask, then test it manually:
 
 ```
-pip3 install Flask
-pip install flask-restful
-pip install flask_cors
-cd DDS
+pip3 install -r requirements.txt
 python3 -m src.api
 # In a separate terminal window…
 curl --header "Content-Type: application/json"   --request POST   --data '{"hands":{"S":["D3", "C6", "DT", "D8", "DJ", "D6", "CA", "C3", "S2", "C2", "C4", "S9", "S7"],"W":["DA", "S4", "HT", "C5", "D4", "D7", "S6", "S3", "DK", "CT", "D2", "SK","H8"],"N":["C7", "H6", "H7", "H9", "CJ", "SA", "S8", "SQ", "D5", "S5", "HK", "C8", "HA"],"E":["H2", "H5", "CQ", "D9", "H4", "ST", "HQ", "SJ", "HJ", "DQ", "H3", "C9", "CK"]}}'   http://localhost:5000/api/dds-table/

--- a/README.md
+++ b/README.md
@@ -8,16 +8,18 @@ Uses Bo Hagland's solver https://github.com/dds-bridge/dds -- requires the libdd
 Credit to Alexis Rimbaud of NukkAI for the python dds wrapper.
 
 
-# Build and install libdds library for local testing
+# Build the C++ library for local testing
 
 ```
 make libdds-build
-cd libdds/.build
 ```
 
 The python loader looks for the library from libdds/.build/src. If the file is
 found from build directory then the found library is preferred before a library
 in a system directory.
+
+If you want to change the C++ library's build configuration,
+[README.libdds.md](README.libdds.md) provides information about the process.
 
 # Install a local server using Flask, then test it manually:
 


### PR DESCRIPTION
## doc(README): Improve C++ library build documentation

Add build and test instructions for C++ library. These commands are
based on build process initiated by Makefile.

## doc(README): Improve dependency installation

Dependencies should be held in one place. The requirements.txt offers a
natural place to maintain all requirements which can be installed using
a pip command.

## doc(README.gcp): Remove C++ library instructions

The C++ library instructions became outdated with changes to automate
submodule build. The automation takes care of C++ library build process
which allows the cloud build skip directly to the python part of
instructions.

There is a small addition to use libdds-build target before trying local
server. This makes sure automate C++ library build process will be done
before attempting to use the library.