### PR TITLE
Use new production endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,13 @@ ensure_ns:
 run_local_tests: libdds-build
 	python3 -m unittest discover ${VERBOSE_TEST}
 
-curl_local:
+curl_local_URL := http://localhost:5000/api/dds-table/
+curl_prod_URL  := https://dds.prod.globalbridge.app/api/dds-table/
+CURL_URL       ?= ${$@_URL}
+
+# Slightly unusual approach in order to keep the command-line output legible.
+# May need to add "--insecure" when we add more targets.
+curl_local curl_prod:
 	curl \
 	--header "Content-Type: application/json" \
 	--data \
@@ -71,5 +77,4 @@ curl_local:
 		"W":["DA", "S4", "HT", "C5", "D4", "D7", "S6", "S3", "DK", "CT", "D2", "SK", "H8"],    \
 		"N":["C7", "H6", "H7", "H9", "CJ", "SA", "S8", "SQ", "D5", "S5", "HK", "C8", "HA"],    \
 		"E":["H2", "H5", "CQ", "D9", "H4", "ST", "HQ", "SJ", "HJ", "DQ", "H3", "C9", "CK"] }}' \
-	http://localhost:5000/api/dds-table/
-
+	${CURL_URL}

--- a/README.gcp.md
+++ b/README.gcp.md
@@ -65,7 +65,7 @@ python3 -m src.api
 Open a new terminal tab by pressing the "+" button in the cloud shell menu bar.
 
 ```
-curl --header "Content-Type: application/json" --data '{"hands":{"S":["D3", "C6", "DT", "D8", "DJ", "D6", "CA", "C3", "S2", "C2", "C4", "S9", "S7"],"W":["DA", "S4", "HT", "C5", "D4", "D7", "S6", "S3", "DK", "CT", "D2", "SK","H8"],"N":["C7", "H6", "H7", "H9", "CJ", "SA", "S8", "SQ", "D5", "S5", "HK", "C8", "HA"],"E":["H2", "H5", "CQ", "D9", "H4", "ST", "HQ", "SJ", "HJ", "DQ", "H3", "C9", "CK"]}}'   http://localhost:5000/api/dds-table/
+make curl_local
 ```
 
 # Create a docker image and deploy it to the GCP
@@ -112,7 +112,7 @@ Now view the logs:
 Now send your service a POST request, either from the cloud shell or your local machine:
 
 ```
-curl --header "Content-Type: application/json" --data '{"hands":{"S":["D3", "C6", "DT", "D8", "DJ", "D6", "CA", "C3", "S2", "C2", "C4", "S9", "S7"],"W":["DA", "S4", "HT", "C5", "D4", "D7", "S6", "S3", "DK", "CT", "D2", "SK","H8"],"N":["C7", "H6", "H7", "H9", "CJ", "SA", "S8", "SQ", "D5", "S5", "HK", "C8", "HA"],"E":["H2", "H5", "CQ", "D9", "H4", "ST", "HQ", "SJ", "HJ", "DQ", "H3", "C9", "CK"]}}'   https://dds.hackathon.globalbridge.app/api/dds-table/ 
+make curl_prod
 ```
 
 When you refresh the logs page you should see a line showing your POST.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pip install flask_cors
 cd DDS
 python3 -m src.api
 # In a separate terminal window…
-curl --header "Content-Type: application/json"   --request POST   --data '{"hands":{"S":["D3", "C6", "DT", "D8", "DJ", "D6", "CA", "C3", "S2", "C2", "C4", "S9", "S7"],"W":["DA", "S4", "HT", "C5", "D4", "D7", "S6", "S3", "DK", "CT", "D2", "SK","H8"],"N":["C7", "H6", "H7", "H9", "CJ", "SA", "S8", "SQ", "D5", "S5", "HK", "C8", "HA"],"E":["H2", "H5", "CQ", "D9", "H4", "ST", "HQ", "SJ", "HJ", "DQ", "H3", "C9", "CK"]}}'   http://localhost:5000/api/dds-table/
+make curl_local
 ```
 
 # Install Docker for MacOS

--- a/frontend/dds_mvp.js
+++ b/frontend/dds_mvp.js
@@ -217,8 +217,8 @@ function sendJSON() {
     
     // For testing backend changes locally
     // const URL = "http://localhost:5000/api/dds-table/";
-    
-    const URL = "https://dds.globalbridge.app/api/dds-table/";
+
+    const URL = "https://dds.prod.globalbridge.app/api/dds-table/";
 
     xhr.open("POST", URL, true);
 


### PR DESCRIPTION
Replaced the old GCP endpoint with the current one and added a new make target, `curl_prod`.