### PR TITLE
Submodule update fix mac hang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ release: build push
 
 # Make sure submodules have been initialized and libdds has latest code
 libdds/.git libdds-update:
-	git submodule update --init --rebase
+	git submodule update --init --recursive
 
 # Configure libdds build
 # Dependency makes sure submodules have been initialized


### PR DESCRIPTION
### Update submodule

The update includes fix for C++ initialization on Mac.

### Fix parameters to submodule update …

Rebase argument for submodule update is wrong. It should be --recursive
to make fetch all submodules.